### PR TITLE
coerce buffer to string in parseDeps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ module.exports = function(_arg) {
   parseDeps = function(data, path, depsList, callback) {
     var altExts, deps, parent, prefixed;
     parent = sysPath.dirname(path);
-    deps = data.split('\n').map(function(line) {
+    deps = data.toString().split('\n').map(function(line) {
       return line.match(regexp);
     }).filter(function(match) {
       return (match != null ? match.length : void 0) > 0;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -24,6 +24,7 @@ module.exports =
   parseDeps = (data, path, depsList, callback) ->
     parent = sysPath.dirname path
     deps = data
+      .toString()
       .split('\n')
       .map (line) ->
         line.match regexp


### PR DESCRIPTION
@antigoliath and I have been testing the fix for brunch/sass-brunch#17. We ran into an issue whereby parseDeps sometimes receives a buffer rather than a string as its first argument. This pull request fixes the problem by coercing the value to a string before splitting on `\n`.
