### PR TITLE
Allow less import options

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,7 +12,7 @@ defaultSettings = (extname) ->
 			regexp: /^\s*(?:@import|@require)\s+['"]?([^'"]+)['"]?/
 			exclusion: 'nib'
 		when 'less'
-			regexp: /^\s*@import\s+['"]([^'"]+)['"]/
+			regexp: /^\s*@import\s+(?:\(\w+\)\s*)?['"]([^'"]+)['"]/
 		when 'scss', 'sass'
 			regexp: /^\s*@import\s+['"]?([^'"]+)['"]?/
 			prefix: '_'


### PR DESCRIPTION
Less allows for import options as documented [here](http://lesscss.org/features/#import-options).

Example: `@import (keyword) "filename";`
