### PR TITLE
Add a default defaultSettings for other extensions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,8 @@ defaultSettings = function(extname) {
       return {
         regexp: /^\s*@import\s*(?:url\()?['"]([^'"]+)['"]/
       };
+    default:
+      return {};
   }
 };
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -28,6 +28,8 @@ defaultSettings = (extname) ->
 			]
 		when 'css'
 			regexp: /^\s*@import\s*(?:url\()?['"]([^'"]+)['"]/
+		else
+			{}
 
 progenyConstructor = (mode, settings = {}) ->
 	{


### PR DESCRIPTION
I'm pretty sure this would benefit for custom implementations. Currently if you use a custom extension name for non-supported file types it'll throw a bunch of errors because you have to be super specific and fill in all the options.