### PR TITLE
new features: skip comments by default and custom resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ var progenyConfig = {
     // path progeny thinks a depencency could be located at.
     potentialDeps: true,
 
+    // By default progeny will strip all line comments like "// ..." and
+    // multiline comments like "/* ... */". You could disable this behavior.
+    skipCommentes: true;
+
+    // Custom resolver allows to preprocess dependency name. For example, webpack
+    // has well known way to reference node_modules-related path with ~ in the
+    // beginning of import name.
+    // Return true, undefined or null to accept dependency without changes.
+    // Return false to reject dependency.
+    // Return new filename to override dependency.
+    resolver: function (depFilename, parentDir, parentFilename) {
+      if (depFilename.startsWith('~')) {
+        var absPath = path.resolve(path.join('.', 'node_modules', depFilename.substr(1)));
+        return path.relative(parentDir, absPath);
+      }
+    },
+
     // Print dependency resolution information to console.log
     debug: true
 };

--- a/index.js
+++ b/index.js
@@ -69,11 +69,19 @@ function progenyConstructor(mode, settings) {
   var globDeps = settings.globDeps;
   var reverseArgs = settings.reverseArgs;
   var debug = settings.debug;
+  var resolver = settings.resolver;
+  var skipComments = settings.skipComments;
 
   function parseDeps(path, source, depsList, callback) {
     var parent;
     if (path) {
       parent = sysPath.dirname(path);
+    }
+
+    if (skipComments) {
+      source = source
+        .replace(/\/\/[^\r\n]*(\r\n|\r|\n|$)/g, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '');
     }
 
     var globs = [];
@@ -133,6 +141,26 @@ function progenyConstructor(mode, settings) {
 
     if (Array.isArray(altPaths)) {
       [].push.apply(dirs, altPaths);
+    }
+
+    if (resolver) {
+      paths = paths
+        .map(function (filename) {
+          var resolvedPath = resolver(filename, parent, path);
+          if (resolvedPath === false) {
+            return false;
+          } else if (resolvedPath === true
+            || resolvedPath === null
+            || resolvedPath === undefined
+          ) {
+            return filename;
+          } else {
+            return resolvedPath;
+          }
+        })
+        .filter(function (path) {
+          return path !== false;
+        });
     }
 
     var deps = [];
@@ -272,6 +300,8 @@ function progenyConstructor(mode, settings) {
     if (moduleDep == null) moduleDep = def.moduleDep;
     if (globDeps == null) globDeps = def.globDeps;
     if (debug == null) debug = def.debug;
+    if (resolver == null) resolver = def.resolver;
+    if (skipComments == null) skipComments = true;
 
     function run() {
       parseDeps(path, source, depsList, function () {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function progenyConstructor(mode, settings) {
 
     if (skipComments) {
       source = source
-        .replace(/\/\/[^\r\n]*(\r\n|\r|\n|$)/g, '')
+        .replace(/\/\/[^\r\n]*(\r\n|\r|\n|$)/g, '$1')
         .replace(/\/\*[\s\S]*?\*\//g, '');
     }
 

--- a/index.js
+++ b/index.js
@@ -149,14 +149,14 @@ function progenyConstructor(mode, settings) {
           var resolvedPath = resolver(filename, parent, path);
           if (resolvedPath === false) {
             return false;
-          } else if (resolvedPath === true
+          }
+          if (resolvedPath === true
             || resolvedPath === null
             || resolvedPath === undefined
           ) {
             return filename;
-          } else {
-            return resolvedPath;
           }
+          return resolvedPath;
         })
         .filter(function (path) {
           return path !== false;


### PR DESCRIPTION
1) Skip Comments feature allows to ignore imports in comments and generate correct dependency list for Bootstrap 4, for example, which has `// .class-name { @import "bootstrap"; }` in `_reboot.scss`

2) Custom Resolver allows to use custom resolver and generate correct dependency list if some magic paths are used. For example, in webpack there is a `~` prefix to reference `node_modules` and in jspm there is a `jspm:` prefix to reference `jspm_modules`.