### PR TITLE
Fix uncaught exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function progenyConstructor(mode, settings) {
       mdeps = multipass.slice(0, -1)
         .reduce(function (vals, regex) {
           return vals.map(function (val) {
-            return val ? val.match(regex) : [];
+            return val ? (val.match(regex) || []) : [];
           }).reduce(function (flat, val) {
             return flat.concat(val);
           }, []);
@@ -113,10 +113,10 @@ function progenyConstructor(mode, settings) {
         return line.match(regexp);
       })
       .filter(function (match) {
-        return match && match.length;
+        return match && (match.length > 1);
       })
       .map(function (match) {
-        return match[1];
+        return match[1].trim();
       })
       .concat(mdeps)
       .filter(function (path) {

--- a/test.js
+++ b/test.js
@@ -100,6 +100,13 @@ describe('progeny', function() {
       done();
     });
   });
+
+  it('should skip empty dependencies', function (done) {
+    progeny(o)('foo.scss', '@import ""', function (err, deps) {
+      assert.deepEqual(deps, []);
+      done();
+    });
+  });
 });
 
 describe('progeny.Sync', function () {
@@ -431,6 +438,33 @@ describe('progeny configuration', function () {
         assert.deepEqual(deps, ['bar.less']);
         done();
       });
+    });
+  });
+
+  describe('multipass', function () {
+    var regexps = [
+      /(?:'[^']+\.twig')|(?:"[^"]+\.twig")/g,
+      /^.(.+).$/
+    ];
+
+    it('should resolve multiple dependencies in one line', function (done) {
+        progeny({
+          potentialDeps: true,
+          multipass: regexps
+        })('base.twig', '{% include ["partial1.twig", "partial2.twig"] %}', function (err, deps) {
+          assert.deepEqual(deps, ['partial1.twig', 'partial2.twig']);
+          done();
+        });
+    });
+
+    it('should return empty array when there are no dependencies', function (done) {
+        progeny({
+          potentialDeps: true,
+          multipass: regexps
+        })('base.twig', '{# No dependency here! #}', function (err, deps) {
+          assert.deepEqual(deps, []);
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
This PR fixes two uncaught exceptions thrown when: 
1. there are empty dependencies (e.g. `@import "";`)
2. there is no dependency and 2-stage multipass is set

Tests for both cases are also provided.