### PR TITLE
Enable moduleDep options fo Sass files by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function defaultSettings(extName) {
         regexp: /^\s*@import\s*['"]?([^'"]+)['"]?/,
         prefix: '_',
         exclusion: /^compass/,
+        moduleDep: true,
         extensionsList: ['scss', 'sass'],
         multipass: [
           /@import[^;]+;/g,


### PR DESCRIPTION
dart-sass and LibSass since 3.6.0 allow implicit imports of index files https://sass-lang.com/documentation/at-rules/import#index-files.